### PR TITLE
use boundingBox.minY for player Y coord

### DIFF
--- a/src/main/java/com/zyin/zyinhud/mods/Coordinates.java
+++ b/src/main/java/com/zyin/zyinhud/mods/Coordinates.java
@@ -155,7 +155,7 @@ public class Coordinates extends ZyinHUDModBase
     }
     public static int GetYCoordinate()
     {
-    	return (int) Math.floor(mc.thePlayer.posY - 1.62);	//.posY returns the player's eye height, which is 1.62 blocks off the ground
+    	return (int) Math.floor(mc.thePlayer.boundingBox.minY);	//use feet height; .posY returns the player's eye height, which is normally 1.62 blocks off the ground
     }
     public static int GetZCoordinate()
     {


### PR DESCRIPTION
this is the way it's done in F3 debug info and prevents the Y coord from
being too low when crouching, like it is when we just subtract 1.62 (the
standing eye height)
